### PR TITLE
AIRNEIS-74 : Linter configuration for GoSec

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
           cache: true
       # Check that the code is clean
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           working-directory: ./back
           version: v1.54

--- a/back/.golangci.yml
+++ b/back/.golangci.yml
@@ -1,0 +1,158 @@
+# Options for analysis running.
+run:
+  concurrency: 4
+  timeout: 30s
+  issues-exit-code: 1
+  tests: true
+  modules-download-mode: readonly
+  allow-parallel-runners: true
+  allow-serial-runners: true
+  go: '1.21'
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+# All available settings of specific linters.
+linters-settings:
+  # See the dedicated "linters-settings" documentation section.
+  gosec:
+    # To select a subset of rules to run.
+    # Available rules: https://github.com/securego/gosec#available-rules
+    # Default: [] - means include all rules
+    includes:
+      - G101 # Look for hard coded credentials
+      - G102 # Bind to all interfaces
+      - G103 # Audit the use of unsafe block
+      - G104 # Audit errors not checked
+      - G106 # Audit the use of ssh.InsecureIgnoreHostKey
+      - G107 # Url provided to HTTP request as taint input
+      - G108 # Profiling endpoint automatically exposed on /debug/pprof
+      - G109 # Potential Integer overflow made by strconv.Atoi result conversion to int16/32
+      - G110 # Potential DoS vulnerability via decompression bomb
+      - G111 # Potential directory traversal
+      - G112 # Potential slowloris attack
+      - G113 # Usage of Rat.SetString in math/big with an overflow (CVE-2022-23772)
+      - G114 # Use of net/http serve function that has no support for setting timeouts
+      - G201 # SQL query construction using format string
+      - G202 # SQL query construction using string concatenation
+      - G203 # Use of unescaped data in HTML templates
+      - G204 # Audit use of command execution
+      - G301 # Poor file permissions used when creating a directory
+      - G302 # Poor file permissions used with chmod
+      - G303 # Creating tempfile using a predictable path
+      - G304 # File path provided as taint input
+      - G305 # File traversal when extracting zip/tar archive
+      - G306 # Poor file permissions used when writing to a new file
+      - G307 # Poor file permissions used when creating a file with os.Create
+      - G401 # Detect the usage of DES, RC4, MD5 or SHA1
+      - G402 # Look for bad TLS connection settings
+      - G403 # Ensure minimum RSA key length of 2048 bits
+      - G404 # Insecure random number source (rand)
+      - G501 # Import blocklist: crypto/md5
+      - G502 # Import blocklist: crypto/des
+      - G503 # Import blocklist: crypto/rc4
+      - G504 # Import blocklist: net/http/cgi
+      - G505 # Import blocklist: crypto/sha1
+      - G601 # Implicit memory aliasing of items from a range statement
+      - G602 # Slice access out of bounds
+    # To specify a set of rules to explicitly exclude.
+    # Available rules: https://github.com/securego/gosec#available-rules
+    # Default: []
+    config:
+      # Globals are applicable to all rules.
+      global:
+        # If true, ignore #nosec in comments (and an alternative as well).
+        nosec: true
+        show-ignored: true
+        # Audit mode enables addition checks that for normal code analysis might be too nosy.
+        audit: true
+      G101:
+        # Regexp pattern for variables and constants to find.
+        # Default: "(?i)passwd|pass|password|pwd|secret|token|pw|apiKey|bearer|cred"
+        pattern: "(?i)example"
+        # If true, complain about all cases (even with low entropy).
+        # Default: false
+        ignore_entropy: false
+        # Maximum allowed entropy of the string.
+        # Default: "80.0"
+        entropy_threshold: "80.0"
+        # Maximum allowed value of entropy/string length.
+        # Is taken into account if entropy >= entropy_threshold/2.
+        # Default: "3.0"
+        per_char_threshold: "3.0"
+        # Calculate entropy for first N chars of the string.
+        # Default: "16"
+        truncate: "32"
+      # Additional functions to ignore while checking unhandled errors.
+      # Following functions always ignored:
+      #   bytes.Buffer:
+      #     - Write
+      #     - WriteByte
+      #     - WriteRune
+      #     - WriteString
+      #   fmt:
+      #     - Print
+      #     - Printf
+      #     - Println
+      #     - Fprint
+      #     - Fprintf
+      #     - Fprintln
+      #   strings.Builder:
+      #     - Write
+      #     - WriteByte
+      #     - WriteRune
+      #     - WriteString
+      #   io.PipeWriter:
+      #     - CloseWithError
+      #   hash.Hash:
+      #     - Write
+      #   os:
+      #     - Unsetenv
+      # Default: {}
+      G104:
+        fmt:
+          - Fscanf
+      G111:
+        # Regexp pattern to find potential directory traversal.
+        # Default: "http\\.Dir\\(\"\\/\"\\)|http\\.Dir\\('\\/'\\)"
+        pattern: "custom\\.Dir\\(\\)"
+      # Maximum allowed permissions mode for os.Mkdir and os.MkdirAll
+      # Default: "0750"
+      G301: "0750"
+      # Maximum allowed permissions mode for os.OpenFile and os.Chmod
+      # Default: "0600"
+      G302: "0600"
+      # Maximum allowed permissions mode for os.WriteFile and ioutil.WriteFile
+      # Default: "0600"
+      G306: "0600"
+linters:
+  # See the dedicated "linters" documentation section.
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gosec
+issues:
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
+  # Default: 50
+  max-issues-per-linter: 0
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 0
+  # Show only new issues: if there are unstaged changes or untracked files,
+  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
+  # It's a super-useful option for integration of golangci-lint into existing large codebase.
+  # It's not practical to fix all existing issues at the moment of integration:
+  # much better don't allow issues in new code.
+  #
+  # Default: false
+  new: true
+  # Fix found issues (if it's supported by the linter).
+  # Default: false
+  fix: true
+  

--- a/back/.golangci.yml
+++ b/back/.golangci.yml
@@ -66,56 +66,9 @@ linters-settings:
         show-ignored: true
         # Audit mode enables addition checks that for normal code analysis might be too nosy.
         audit: true
-      G101:
-        # Regexp pattern for variables and constants to find.
-        # Default: "(?i)passwd|pass|password|pwd|secret|token|pw|apiKey|bearer|cred"
-        pattern: "(?i)example"
-        # If true, complain about all cases (even with low entropy).
-        # Default: false
-        ignore_entropy: false
-        # Maximum allowed entropy of the string.
-        # Default: "80.0"
-        entropy_threshold: "80.0"
-        # Maximum allowed value of entropy/string length.
-        # Is taken into account if entropy >= entropy_threshold/2.
-        # Default: "3.0"
-        per_char_threshold: "3.0"
-        # Calculate entropy for first N chars of the string.
-        # Default: "16"
-        truncate: "32"
-      # Additional functions to ignore while checking unhandled errors.
-      # Following functions always ignored:
-      #   bytes.Buffer:
-      #     - Write
-      #     - WriteByte
-      #     - WriteRune
-      #     - WriteString
-      #   fmt:
-      #     - Print
-      #     - Printf
-      #     - Println
-      #     - Fprint
-      #     - Fprintf
-      #     - Fprintln
-      #   strings.Builder:
-      #     - Write
-      #     - WriteByte
-      #     - WriteRune
-      #     - WriteString
-      #   io.PipeWriter:
-      #     - CloseWithError
-      #   hash.Hash:
-      #     - Write
-      #   os:
-      #     - Unsetenv
-      # Default: {}
       G104:
         fmt:
           - Fscanf
-      G111:
-        # Regexp pattern to find potential directory traversal.
-        # Default: "http\\.Dir\\(\"\\/\"\\)|http\\.Dir\\('\\/'\\)"
-        pattern: "custom\\.Dir\\(\\)"
       # Maximum allowed permissions mode for os.Mkdir and os.MkdirAll
       # Default: "0750"
       G301: "0750"


### PR DESCRIPTION
- Added linter for security vulnerabilities 

Example of hardcoded token that golangci-lint found locally. 

<img width="1194" alt="Screenshot 2024-03-17 at 19 26 28" src="https://github.com/KrispyTech/airneis/assets/75094434/2fa910af-79f3-407f-9fce-14634dfdd6c4">
