### PR TITLE
Linter - Go : Exclude rule (line-length-limit) on models directory

### DIFF
--- a/back/.golangci.yml
+++ b/back/.golangci.yml
@@ -568,3 +568,9 @@ issues:
   # Fix found issues (if it's supported by the linter).
   # Default: false
   fix: true
+  exclude-rules:
+    - path: src/models/
+      text: "line-length-limit"
+      linters:
+        - revive
+  


### PR DESCRIPTION
# DONE 
Exclude rule (line-length-limit) on models directory to be able to have validation rules. 

cc : @BarnabePILLIAUDIN 

<img width="1512" alt="Screenshot 2024-03-21 at 18 23 29" src="https://github.com/KrispyTech/airneis/assets/75094434/b7a6daf6-251e-47e7-b49e-3a1c6fb99db3">
